### PR TITLE
Add support for custom authorization client 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.9.0 (2022-06-07)
 
-### -Added new option `authorizationClient`
+### - Added new option `authorizationClient` to `RealityDataClientOptions`
 
 Defines Authorization client to use to get access token to Context Share API (authority: <https://ims.bentley.com> )
 When defined it will ignore accessToken from API parameters and will get an access token from this client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.9.0 (2022-06-07)
+
+### -Added new option `authorizationClient`
+
+Defines Authorization client to use to get access token to Context Share API (authority: <https://ims.bentley.com> )
+When defined it will ignore accessToken from API parameters and will get an access token from this client.

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,18 +287,18 @@
       }
     },
     "@itwin/core-geometry": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@itwin/core-geometry/-/core-geometry-3.0.0.tgz",
-      "integrity": "sha512-00KlHwya2ZhYF4XmrbRJ6RyxaROJJ3j9rTiGKdT8oYvuf+dm5fRA1a+V8HPPKonSiTwpmQYOr0Ro3X6v+CjpDQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@itwin/core-geometry/-/core-geometry-3.2.0.tgz",
+      "integrity": "sha512-CJ01MxXJfmoW0z3iquvCrtnxPvx/N9Hx8Q40RIsU7asWVPT5Lb1JmSBlPkfxSJ15zN8wZZhFM/x7KWemtPng2Q==",
       "requires": {
-        "@itwin/core-bentley": "3.0.0",
+        "@itwin/core-bentley": "3.2.0",
         "flatbuffers": "~1.12.0"
       },
       "dependencies": {
         "@itwin/core-bentley": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@itwin/core-bentley/-/core-bentley-3.0.0.tgz",
-          "integrity": "sha512-tfFM6lKVtjUMrQM/amHrEgJRtIhpqI5bGMtX8MwM9bBeH3hLGY8eTA8A7ReflWmUky+gHhpvN3TGsC7VLqqrIw=="
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@itwin/core-bentley/-/core-bentley-3.2.0.tgz",
+          "integrity": "sha512-VnxqQxwXvJuAE5sbKmhqdqpEWVp9N1uWdAD4LopUCY/B0GHdZ7fKigQ7GH/m2b3XxnmIzCH8OwjgaEO/Ppe5Sw=="
         }
       }
     },
@@ -3815,9 +3815,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/reality-data-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Reality Data Client for the iTwin platform",
   "main": "lib/cjs/reality-data-client.js",
   "module": "lib/esm/reality-data-client.js",

--- a/src/RealityDataClient.ts
+++ b/src/RealityDataClient.ts
@@ -90,13 +90,6 @@ export class RealityDataAccessClient implements RealityDataAccess {
   }
 
   /**
-   * Returns an accessToken from the authorizationClient in RealityDataClientOptions or an empty string if undefined
-   */
-  public async getAccessToken(): Promise<string> {
-    return this.authorizationClient ? this.authorizationClient.getAccessToken() : "";
-  }
-
-  /**
    * Try to use authorizationClient in RealityDataClientOptions to get the access token
    * otherwise, will return the input token
    * This is a workaround to support different authorization client for the reality data client and iTwin-core.


### PR DESCRIPTION
Add an option to provide an authorization client that will be used to get an access token to access Context Share API (authority: https://ims.bentley.com )
When this option is defined, it will ignore accessToken from API parameters and will get an access token from this client.